### PR TITLE
add Zenodo DOI

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -10,6 +10,7 @@ authors:
 - family-names: Lohweg
   given-names: Volker
   orcid: https://orcid.org/0000-0002-3325-7887
+doi: 10.5281/zenodo.7852139
 type: dataset
 license: CC-BY-4.0
 url: https://github.com/pystiche/NPRportrait-segmentation

--- a/README.md
+++ b/README.md
@@ -162,9 +162,9 @@ If you use the _NPRportrait-segmentation_ dataset provided in this repository, p
 ```bibtex
 @misc{Bultemeier_NPRportrait-segmentation,
   author = {Bültemeier, Julian and Meier, Philip and Lohweg, Volker},
+  doi    = {10.5281/zenodo.7852139},
   title  = {{NPRportrait-segmentation}},
-  url    = {https://github.com/pystiche/NPRportrait-segmentation},
-  doi    = {}
+  url    = {https://github.com/pystiche/NPRportrait-segmentation}
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # NPRportrait segmentation
 
+[![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.7852139.svg)](https://doi.org/10.5281/zenodo.7852139)
+
 - [Introduction](#introduction)
 - [Methodology](#methodology)
 - [Usage](#usage)
@@ -161,7 +163,8 @@ If you use the _NPRportrait-segmentation_ dataset provided in this repository, p
 @misc{Bultemeier_NPRportrait-segmentation,
   author = {Bültemeier, Julian and Meier, Philip and Lohweg, Volker},
   title  = {{NPRportrait-segmentation}},
-  url    = {https://github.com/pystiche/NPRportrait-segmentation}
+  url    = {https://github.com/pystiche/NPRportrait-segmentation},
+  doi    = {}
 }
 ```
 


### PR DESCRIPTION
After the initial release, we now have a DOI from Zenodo and can put it into the citation information and as badge into the README. cc @jbueltemeier 